### PR TITLE
Add bulk create customers and bulk assign plan methods

### DIFF
--- a/lib/metrifox_sdk/customers/api.rb
+++ b/lib/metrifox_sdk/customers/api.rb
@@ -75,6 +75,13 @@ module MetrifoxSDK::Customers
       parse_response(response, "Failed to upload CSV")
     end
 
+    def bulk_create_request(base_url, api_key, request_payload)
+      uri = URI.join(base_url, "customers/bulk-create")
+      body = serialize_customer_request(request_payload)
+      response = make_request(uri, "POST", api_key, body)
+      parse_response(response, "Failed to Bulk Create Customers")
+    end
+
     private
 
     def serialize_customer_request(request)

--- a/lib/metrifox_sdk/customers/module.rb
+++ b/lib/metrifox_sdk/customers/module.rb
@@ -54,6 +54,11 @@ module MetrifoxSDK
         api.upload_customers_csv(base_url, api_key, file_path)
       end
 
+      def bulk_create(request_payload)
+        validate_api_key!
+        api.bulk_create_request(base_url, api_key, request_payload)
+      end
+
       private
 
       def api

--- a/lib/metrifox_sdk/subscriptions/api.rb
+++ b/lib/metrifox_sdk/subscriptions/api.rb
@@ -22,5 +22,18 @@ module MetrifoxSDK::Subscriptions
       response = make_request(uri, "GET", api_key)
       parse_response(response, "Failed to Fetch Entitlements Usage")
     end
+
+    def bulk_assign_plan_request(base_url, api_key, request_payload)
+      uri = URI.join(base_url, "subscriptions/bulk-assign-plan")
+      body = if request_payload.respond_to?(:to_h)
+               request_payload.to_h.compact
+             elsif request_payload.is_a?(Hash)
+               request_payload.compact
+             else
+               raise ArgumentError, "Invalid request format"
+             end
+      response = make_request(uri, "POST", api_key, body)
+      parse_response(response, "Failed to Bulk Assign Plan")
+    end
   end
 end

--- a/lib/metrifox_sdk/subscriptions/module.rb
+++ b/lib/metrifox_sdk/subscriptions/module.rb
@@ -19,6 +19,19 @@ module MetrifoxSDK
         api.entitlements_usage_request(base_url, api_key, subscription_id)
       end
 
+      def bulk_assign_plan(customer_keys:, plan_key:, billing_interval: nil, currency_code: nil, items: nil, skip_invoice: nil)
+        validate_api_key!
+        request_payload = {
+          customer_keys: customer_keys,
+          plan_key: plan_key,
+          billing_interval: billing_interval,
+          currency_code: currency_code,
+          items: items,
+          skip_invoice: skip_invoice
+        }.compact
+        api.bulk_assign_plan_request(base_url, api_key, request_payload)
+      end
+
       private
 
       def api

--- a/spec/customers_spec.rb
+++ b/spec/customers_spec.rb
@@ -572,6 +572,154 @@ RSpec.describe MetrifoxSDK::Customers::Module do
     end
   end
 
+  describe "#bulk_create" do
+    let(:bulk_payload) do
+      {
+        customers: [
+          {
+            customer_type: "BUSINESS",
+            customer_key: "acme_corp_001",
+            primary_email: "contact@acmecorp.com",
+            legal_name: "Acme Corporation",
+            display_name: "Acme Corp"
+          },
+          {
+            customer_type: "INDIVIDUAL",
+            customer_key: "jane_doe_001",
+            primary_email: "jane@example.com",
+            first_name: "Jane",
+            last_name: "Doe"
+          }
+        ]
+      }
+    end
+
+    let(:expected_response) do
+      {
+        "statusCode" => 200,
+        "message" => "Bulk Customer Creation Completed",
+        "meta" => {},
+        "data" => {
+          "total" => 2,
+          "successful_count" => 2,
+          "failed_count" => 0,
+          "customers_created" => [
+            {
+              "index" => 0,
+              "customer_key" => "acme_corp_001",
+              "data" => {
+                "id" => "764c80e3-ed59-44a5-ba07-7ee5ba547774",
+                "customer_type" => "BUSINESS",
+                "primary_email" => "contact@acmecorp.com",
+                "display_name" => "Acme Corp"
+              }
+            },
+            {
+              "index" => 1,
+              "customer_key" => "jane_doe_001",
+              "data" => {
+                "id" => "864c80e3-ed59-44a5-ba07-7ee5ba547775",
+                "customer_type" => "INDIVIDUAL",
+                "primary_email" => "jane@example.com",
+                "display_name" => "Jane Doe"
+              }
+            }
+          ],
+          "customers_failed" => []
+        },
+        "errors" => {}
+      }
+    end
+
+    it "bulk creates customers successfully" do
+      stub_request(:post, "#{base_url}customers/bulk-create")
+        .with(
+          headers: {
+            'x-api-key' => api_key,
+            'Content-Type' => 'application/json'
+          },
+          body: bulk_payload.to_json
+        )
+        .to_return(
+          status: 200,
+          body: expected_response.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      result = customers_module.bulk_create(bulk_payload)
+      expect(result).to eq(expected_response)
+      expect(result["statusCode"]).to eq(200)
+      expect(result["data"]["successful_count"]).to eq(2)
+      expect(result["data"]["failed_count"]).to eq(0)
+      expect(result["data"]["customers_created"].length).to eq(2)
+    end
+
+    it "handles partial failures" do
+      partial_response = {
+        "statusCode" => 200,
+        "message" => "Bulk Customer Creation Completed",
+        "meta" => {},
+        "data" => {
+          "total" => 2,
+          "successful_count" => 1,
+          "failed_count" => 1,
+          "customers_created" => [
+            {
+              "index" => 0,
+              "customer_key" => "acme_corp_001",
+              "data" => {
+                "id" => "764c80e3-ed59-44a5-ba07-7ee5ba547774",
+                "customer_type" => "BUSINESS",
+                "primary_email" => "contact@acmecorp.com",
+                "display_name" => "Acme Corp"
+              }
+            }
+          ],
+          "customers_failed" => [
+            {
+              "index" => 1,
+              "customer_key" => "jane_doe_001",
+              "error" => "Primary email has already been used"
+            }
+          ]
+        },
+        "errors" => {}
+      }
+
+      stub_request(:post, "#{base_url}customers/bulk-create")
+        .to_return(
+          status: 200,
+          body: partial_response.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      result = customers_module.bulk_create(bulk_payload)
+      expect(result["data"]["successful_count"]).to eq(1)
+      expect(result["data"]["failed_count"]).to eq(1)
+      expect(result["data"]["customers_failed"].first["error"]).to eq("Primary email has already been used")
+    end
+
+    it "handles API errors" do
+      error_response = {
+        "statusCode" => 400,
+        "message" => "At least one customer is required for bulk creation",
+        "meta" => {},
+        "data" => nil,
+        "errors" => {}
+      }
+
+      stub_request(:post, "#{base_url}customers/bulk-create")
+        .to_return(
+          status: 400,
+          body: error_response.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      expect { customers_module.bulk_create({ customers: [] }) }
+        .to raise_error(MetrifoxSDK::APIError, /Failed to Bulk Create Customers: 400/)
+    end
+  end
+
   describe "#list" do
     let(:expected_response) do
       {

--- a/spec/subscriptions_spec.rb
+++ b/spec/subscriptions_spec.rb
@@ -236,4 +236,141 @@ RSpec.describe MetrifoxSDK::Subscriptions::Module do
         .to raise_error(MetrifoxSDK::APIError, /Failed to Fetch Entitlements Usage: 500/)
     end
   end
+
+  describe "#bulk_assign_plan" do
+    let(:expected_response) do
+      {
+        "statusCode" => 200,
+        "message" => "Bulk Plan Assignment Completed",
+        "meta" => {},
+        "data" => {
+          "succeeded" => [
+            { "customer_key" => "cust_001", "subscription_id" => "sub_001" },
+            { "customer_key" => "cust_002", "subscription_id" => "sub_002" }
+          ],
+          "failed" => []
+        },
+        "errors" => {}
+      }
+    end
+
+    it "bulk assigns a plan to multiple customers" do
+      expected_body = {
+        customer_keys: ["cust_001", "cust_002"],
+        plan_key: "pro-plan",
+        billing_interval: "monthly"
+      }
+
+      stub_request(:post, "#{base_url}subscriptions/bulk-assign-plan")
+        .with(
+          headers: {
+            'x-api-key' => api_key,
+            'Content-Type' => 'application/json'
+          },
+          body: expected_body.to_json
+        )
+        .to_return(
+          status: 200,
+          body: expected_response.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      result = subscriptions_module.bulk_assign_plan(
+        customer_keys: ["cust_001", "cust_002"],
+        plan_key: "pro-plan",
+        billing_interval: "monthly"
+      )
+      expect(result).to eq(expected_response)
+      expect(result["statusCode"]).to eq(200)
+      expect(result["data"]["succeeded"].length).to eq(2)
+      expect(result["data"]["failed"]).to be_empty
+    end
+
+    it "sends all optional parameters" do
+      expected_body = {
+        customer_keys: ["cust_001"],
+        plan_key: "pro-plan",
+        billing_interval: "yearly",
+        currency_code: "EUR",
+        items: [{ feature_key: "api_calls", quantity: 10000 }],
+        skip_invoice: true
+      }
+
+      stub_request(:post, "#{base_url}subscriptions/bulk-assign-plan")
+        .with(
+          headers: {
+            'x-api-key' => api_key,
+            'Content-Type' => 'application/json'
+          },
+          body: expected_body.to_json
+        )
+        .to_return(
+          status: 200,
+          body: expected_response.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      result = subscriptions_module.bulk_assign_plan(
+        customer_keys: ["cust_001"],
+        plan_key: "pro-plan",
+        billing_interval: "yearly",
+        currency_code: "EUR",
+        items: [{ feature_key: "api_calls", quantity: 10000 }],
+        skip_invoice: true
+      )
+      expect(result).to eq(expected_response)
+    end
+
+    it "handles partial failures" do
+      partial_response = {
+        "statusCode" => 200,
+        "message" => "Bulk Plan Assignment Completed",
+        "meta" => {},
+        "data" => {
+          "succeeded" => [
+            { "customer_key" => "cust_001", "subscription_id" => "sub_001" }
+          ],
+          "failed" => [
+            { "customer_key" => "cust_002", "error" => "Customer already has an active subscription" }
+          ]
+        },
+        "errors" => {}
+      }
+
+      stub_request(:post, "#{base_url}subscriptions/bulk-assign-plan")
+        .to_return(
+          status: 200,
+          body: partial_response.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      result = subscriptions_module.bulk_assign_plan(
+        customer_keys: ["cust_001", "cust_002"],
+        plan_key: "pro-plan"
+      )
+      expect(result["data"]["succeeded"].length).to eq(1)
+      expect(result["data"]["failed"].length).to eq(1)
+      expect(result["data"]["failed"].first["error"]).to eq("Customer already has an active subscription")
+    end
+
+    it "handles API errors" do
+      error_response = {
+        "statusCode" => 401,
+        "message" => "Unauthorized",
+        "meta" => {},
+        "data" => nil,
+        "errors" => {}
+      }
+
+      stub_request(:post, "#{base_url}subscriptions/bulk-assign-plan")
+        .to_return(
+          status: 401,
+          body: error_response.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      expect { subscriptions_module.bulk_assign_plan(customer_keys: ["cust_001"], plan_key: "pro-plan") }
+        .to raise_error(MetrifoxSDK::APIError, /Failed to Bulk Assign Plan: 401/)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Add `customers.bulk_create` method for `POST /api/v1/customers/bulk-create` endpoint
- Add `subscriptions.bulk_assign_plan` method for `POST /api/v1/subscriptions/bulk-assign-plan` endpoint

## Test plan
- [ ] Verify `customers.bulk_create` sends correct POST request to `/customers/bulk-create`
- [ ] Verify `subscriptions.bulk_assign_plan` sends correct POST request with all parameters (customer_keys, plan_key, billing_interval, currency_code, items, skip_invoice)
- [ ] Verify optional parameters are compacted (nil values excluded from payload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)