### PR TITLE
Add wallets module and new customer/checkout/usage methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Add `customers.archive` and `customers.unarchive`.
 - Add `checkout.card_collection_url(subscription_id:, order_id:)` for generating card-collection URLs.
 - Add `usages.list_events` for listing recorded usage events with optional filters and pagination.
+- Add `usages.quantity_price(customer_key:, feature_key:, quantity:)` for computing the price of a usage quantity.
 - Allow overriding the meter service base URL via `meter_service_base_url` config or `METRIFOX_METER_SERVICE_BASE_URL` env var.
 
 ## [1.2.x]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+
+## [1.3.0]
+- Add `wallets` module with `list`, `list_credit_allocations`, and `get_credit_allocation` methods.
+- Add `customers.archive` and `customers.unarchive`.
+- Add `checkout.card_collection_url(subscription_id:, order_id:)` for generating card-collection URLs.
+- Add `usages.list_events` for listing recorded usage events with optional filters and pagination.
+- Allow overriding the meter service base URL via `meter_service_base_url` config or `METRIFOX_METER_SERVICE_BASE_URL` env var.
+
+## [1.2.x]
 - Update usage access and recording to call the meter service (`https://api-meter.metrifox.com`).
 
 ## [1.0.3] - 2025-09-01

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    metrifox-sdk (1.2.0)
+    metrifox-sdk (1.3.0)
       json (~> 2.0)
       mime-types (~> 3.0)
       net-http (~> 0.3)

--- a/README.md
+++ b/README.md
@@ -304,6 +304,27 @@ response["data"].each do |event|
 end
 ```
 
+### Compute Quantity Price
+
+Compute the price for a given quantity of a feature for a customer, based on their plan. Useful for previewing upgrade costs or showing the cost of additional usage before a customer commits.
+
+```ruby
+response = METRIFOX_SDK.usages.quantity_price(
+  customer_key: "customer_123",
+  feature_key: "feature_interview_booking",
+  quantity: 500
+)
+
+puts "#{response['data']['price']} #{response['data']['unit']}"
+
+# For tiered pricing, inspect the per-tier breakdown
+response["data"]["applied_tiers"].each do |tier|
+  puts "  Tier #{tier['first_unit']}-#{tier['last_unit']}: #{tier['units_consumed']} units -> #{tier['tier_price']}"
+end
+```
+
+> Only available to tenants whose plan includes the finance API feature.
+
 ### Wallets
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ METRIFOX_SDK = MetrifoxSDK.init({ api_key: "your-api-key"})
 ENV["METRIFOX_API_KEY"] = "your-api-key"
 METRIFOX_SDK = MetrifoxSDK.init
 
+# Override base URLs (e.g. for staging or self-hosted environments)
+METRIFOX_SDK = MetrifoxSDK.init({
+  api_key: "your-api-key",
+  base_url: "https://api.staging.metrifox.com/api/v1/",
+  meter_service_base_url: "https://api-meter.staging.metrifox.com/"
+})
+
+# The meter service URL can also be set via env var
+ENV["METRIFOX_METER_SERVICE_BASE_URL"] = "https://api-meter.staging.metrifox.com/"
 ```
 
 ### Access Control
@@ -189,6 +198,12 @@ response = METRIFOX_SDK.customers.list({
 # Delete customer
 response = METRIFOX_SDK.customers.delete_customer({ customer_key: "customer_123" })
 
+# Archive customer
+response = METRIFOX_SDK.customers.archive("customer_123")
+
+# Unarchive customer
+response = METRIFOX_SDK.customers.unarchive("customer_123")
+
 ```
 
 ### Bulk Create Customers
@@ -259,6 +274,55 @@ checkout_config = MetrifoxSDK::Types::CheckoutConfig.new(
 )
 
 checkout_url = METRIFOX_SDK.checkout.url(checkout_config)
+```
+
+### Card Collection URL
+
+Generate a hosted URL for collecting a payment method against an existing subscription or order:
+
+```ruby
+# For a subscription
+url = METRIFOX_SDK.checkout.card_collection_url(subscription_id: "sub_uuid_123")
+
+# For an order
+url = METRIFOX_SDK.checkout.card_collection_url(order_id: "order_uuid_456")
+```
+
+### Usage Events
+
+```ruby
+# List usage events with optional filters and pagination
+response = METRIFOX_SDK.usages.list_events(
+  customer_key: "customer_123",   # optional
+  feature_key: "feature_seats",   # optional
+  page: 1,                        # optional
+  per_page: 25                    # optional
+)
+
+response["data"].each do |event|
+  puts "#{event['feature_key']}: #{event['quantity']} at #{event['timestamp']}"
+end
+```
+
+### Wallets
+
+```ruby
+# List wallets for a customer
+response = METRIFOX_SDK.wallets.list("customer_123")
+response["data"].each do |wallet|
+  puts "#{wallet['name']}: #{wallet['balance']} #{wallet['credit_unit_plural']}"
+end
+
+# List credit allocations for a wallet (optionally filtered by status)
+response = METRIFOX_SDK.wallets.list_credit_allocations("wallet_uuid_123")
+response = METRIFOX_SDK.wallets.list_credit_allocations("wallet_uuid_123", status: "active")
+
+# Get a single credit allocation with its transactions
+response = METRIFOX_SDK.wallets.get_credit_allocation("alloc_uuid_123")
+puts response["data"]["amount"]
+response["data"]["transactions"].each do |txn|
+  puts "  #{txn['amount']} at #{txn['created_at']}"
+end
 ```
 
 ### Subscriptions

--- a/lib/metrifox-sdk.rb
+++ b/lib/metrifox-sdk.rb
@@ -11,6 +11,8 @@ require_relative "metrifox_sdk/checkout/api"
 require_relative "metrifox_sdk/checkout/module"
 require_relative "metrifox_sdk/subscriptions/api"
 require_relative "metrifox_sdk/subscriptions/module"
+require_relative "metrifox_sdk/wallets/api"
+require_relative "metrifox_sdk/wallets/module"
 
 module MetrifoxSDK
   class << self

--- a/lib/metrifox_sdk/checkout/api.rb
+++ b/lib/metrifox_sdk/checkout/api.rb
@@ -19,5 +19,13 @@ module MetrifoxSDK::Checkout
       data = parse_response(response, "Failed to generate checkout URL")
       data.dig("data", "checkout_url")
     end
+
+    def generate_card_collection_url(base_url, api_key, query_params)
+      uri = URI.join(base_url, "checkout/generate-card-collection-url")
+      uri.query = URI.encode_www_form(query_params)
+      response = make_request(uri, "GET", api_key)
+      data = parse_response(response, "Failed to generate card collection URL")
+      data.dig("data", "checkout_url")
+    end
   end
 end

--- a/lib/metrifox_sdk/checkout/module.rb
+++ b/lib/metrifox_sdk/checkout/module.rb
@@ -26,6 +26,23 @@ module MetrifoxSDK
         checkout_url
       end
 
+      def card_collection_url(subscription_id: nil, order_id: nil)
+        validate_api_key!
+
+        if (subscription_id.nil? || subscription_id.to_s.empty?) && (order_id.nil? || order_id.to_s.empty?)
+          raise ArgumentError, "Either subscription_id or order_id is required"
+        end
+
+        query_params = {}
+        query_params[:subscription_id] = subscription_id if subscription_id && !subscription_id.to_s.empty?
+        query_params[:order_id] = order_id if order_id && !order_id.to_s.empty?
+
+        checkout_url = api.generate_card_collection_url(base_url, api_key, query_params)
+        raise StandardError, "Card collection URL could not be generated" if checkout_url.nil? || checkout_url.empty?
+
+        checkout_url
+      end
+
       private
 
       def get_checkout_key

--- a/lib/metrifox_sdk/client.rb
+++ b/lib/metrifox_sdk/client.rb
@@ -15,7 +15,7 @@ module MetrifoxSDK
       @api_key = config[:api_key] || get_api_key_from_environment
       @base_url = config[:base_url] || DEFAULT_BASE_URL
       @web_app_base_url = config[:web_app_base_url] || DEFAULT_WEB_APP_BASE_URL
-      @meter_service_base_url = METER_SERVICE_BASE_URL
+      @meter_service_base_url = config[:meter_service_base_url] || ENV["METRIFOX_METER_SERVICE_BASE_URL"] || METER_SERVICE_BASE_URL
     end
 
     def customers
@@ -32,6 +32,10 @@ module MetrifoxSDK
 
     def subscriptions
       @subscriptions ||= Subscriptions::Module.new(self)
+    end
+
+    def wallets
+      @wallets ||= Wallets::Module.new(self)
     end
 
     private

--- a/lib/metrifox_sdk/customers/api.rb
+++ b/lib/metrifox_sdk/customers/api.rb
@@ -47,6 +47,18 @@ module MetrifoxSDK::Customers
       parse_response(response, "Failed to Check Active Subscription")
     end
 
+    def customer_archive_request(base_url, api_key, customer_key)
+      uri = URI.join(base_url, "customers/#{customer_key}/archive")
+      response = make_request(uri, "POST", api_key)
+      parse_response(response, "Failed to Archive Customer")
+    end
+
+    def customer_unarchive_request(base_url, api_key, customer_key)
+      uri = URI.join(base_url, "customers/#{customer_key}/unarchive")
+      response = make_request(uri, "POST", api_key)
+      parse_response(response, "Failed to Unarchive Customer")
+    end
+
     def customer_list_request(base_url, api_key, request_payload = {})
       uri = URI.join(base_url, "customers")
       

--- a/lib/metrifox_sdk/customers/module.rb
+++ b/lib/metrifox_sdk/customers/module.rb
@@ -44,6 +44,16 @@ module MetrifoxSDK
         delete_customer(request_payload)
       end
 
+      def archive(customer_key)
+        validate_api_key!
+        api.customer_archive_request(base_url, api_key, customer_key)
+      end
+
+      def unarchive(customer_key)
+        validate_api_key!
+        api.customer_unarchive_request(base_url, api_key, customer_key)
+      end
+
       def list(request_payload = {})
         validate_api_key!
         api.customer_list_request(base_url, api_key, request_payload)

--- a/lib/metrifox_sdk/usages/api.rb
+++ b/lib/metrifox_sdk/usages/api.rb
@@ -52,6 +52,13 @@ module MetrifoxSDK::Usages
       parse_response(response, "Failed to record usage")
     end
 
+    def list_events(base_url, api_key, query_params = {})
+      uri = URI.join(base_url, "usage/events")
+      uri.query = URI.encode_www_form(query_params) unless query_params.empty?
+      response = make_request(uri, "GET", api_key)
+      parse_response(response, "Failed to list usage events")
+    end
+
     def fetch_tenant_id(base_url, api_key)
       uri = URI.join(base_url, "auth/get-tenant-id")
       response = make_request(uri, "GET", api_key)

--- a/lib/metrifox_sdk/usages/api.rb
+++ b/lib/metrifox_sdk/usages/api.rb
@@ -59,6 +59,13 @@ module MetrifoxSDK::Usages
       parse_response(response, "Failed to list usage events")
     end
 
+    def quantity_price(base_url, api_key, customer_key:, feature_key:, quantity:)
+      uri = URI.join(base_url, "usage/quantity-price")
+      uri.query = URI.encode_www_form(customer_key: customer_key, feature_key: feature_key, quantity: quantity)
+      response = make_request(uri, "GET", api_key)
+      parse_response(response, "Failed to compute quantity price")
+    end
+
     def fetch_tenant_id(base_url, api_key)
       uri = URI.join(base_url, "auth/get-tenant-id")
       response = make_request(uri, "GET", api_key)

--- a/lib/metrifox_sdk/usages/module.rb
+++ b/lib/metrifox_sdk/usages/module.rb
@@ -24,6 +24,11 @@ module MetrifoxSDK
         api.list_events(meter_service_base_url, api_key, query_params)
       end
 
+      def quantity_price(customer_key:, feature_key:, quantity:)
+        validate_api_key!
+        api.quantity_price(base_url, api_key, customer_key: customer_key, feature_key: feature_key, quantity: quantity)
+      end
+
       def get_tenant_id
         validate_api_key!
         api.fetch_tenant_id(base_url, api_key)

--- a/lib/metrifox_sdk/usages/module.rb
+++ b/lib/metrifox_sdk/usages/module.rb
@@ -14,6 +14,16 @@ module MetrifoxSDK
         api.record_usage(meter_service_base_url, api_key, request_payload)
       end
 
+      def list_events(customer_key: nil, feature_key: nil, page: nil, per_page: nil)
+        validate_api_key!
+        query_params = {}
+        query_params[:customer_key] = customer_key if customer_key
+        query_params[:feature_key] = feature_key if feature_key
+        query_params[:page] = page if page
+        query_params[:per_page] = per_page if per_page
+        api.list_events(meter_service_base_url, api_key, query_params)
+      end
+
       def get_tenant_id
         validate_api_key!
         api.fetch_tenant_id(base_url, api_key)

--- a/lib/metrifox_sdk/version.rb
+++ b/lib/metrifox_sdk/version.rb
@@ -1,3 +1,3 @@
 module MetrifoxSDK
-  VERSION = '1.2.1'
+  VERSION = '1.3.0'
 end

--- a/lib/metrifox_sdk/wallets/api.rb
+++ b/lib/metrifox_sdk/wallets/api.rb
@@ -1,0 +1,28 @@
+require "net/http"
+require "uri"
+require "json"
+require_relative "../base_api"
+
+module MetrifoxSDK::Wallets
+  class API < MetrifoxSDK::BaseApi
+    def list_wallets(base_url, api_key, customer_key)
+      uri = URI.join(base_url, "credit_systems/v2/wallets")
+      uri.query = URI.encode_www_form(customer_key: customer_key)
+      response = make_request(uri, "GET", api_key)
+      parse_response(response, "Failed to list wallets")
+    end
+
+    def list_credit_allocations(base_url, api_key, wallet_id, status: nil)
+      uri = URI.join(base_url, "credit_systems/v2/wallets/#{wallet_id}/credit-allocations")
+      uri.query = URI.encode_www_form(status: status) if status && !status.to_s.empty?
+      response = make_request(uri, "GET", api_key)
+      parse_response(response, "Failed to list credit allocations")
+    end
+
+    def get_credit_allocation(base_url, api_key, allocation_id)
+      uri = URI.join(base_url, "credit_systems/v2/credit-allocations/#{allocation_id}")
+      response = make_request(uri, "GET", api_key)
+      parse_response(response, "Failed to get credit allocation")
+    end
+  end
+end

--- a/lib/metrifox_sdk/wallets/module.rb
+++ b/lib/metrifox_sdk/wallets/module.rb
@@ -1,0 +1,29 @@
+require_relative "api"
+require_relative "../base_module"
+
+module MetrifoxSDK
+  module Wallets
+    class Module < BaseModule
+      def list(customer_key)
+        validate_api_key!
+        api.list_wallets(base_url, api_key, customer_key)
+      end
+
+      def list_credit_allocations(wallet_id, status: nil)
+        validate_api_key!
+        api.list_credit_allocations(base_url, api_key, wallet_id, status: status)
+      end
+
+      def get_credit_allocation(allocation_id)
+        validate_api_key!
+        api.get_credit_allocation(base_url, api_key, allocation_id)
+      end
+
+      private
+
+      def api
+        @api ||= API.new
+      end
+    end
+  end
+end

--- a/spec/checkout_spec.rb
+++ b/spec/checkout_spec.rb
@@ -128,8 +128,68 @@ RSpec.describe MetrifoxSDK::Checkout::Module do
     it "validates API key is not empty" do
       client_with_empty_key = MetrifoxSDK::Client.new(api_key: "")
       checkout_module_empty_key = client_with_empty_key.checkout
-      
+
       expect { checkout_module_empty_key.url({ offering_key: "premium_plan" }) }
+        .to raise_error(MetrifoxSDK::ConfigurationError, /API key required/)
+    end
+  end
+
+  describe "#card_collection_url" do
+    let(:card_url) { "https://checkout.example.com/card-collection/abc123" }
+    let(:card_response) do
+      {
+        "statusCode" => 200,
+        "message" => "Card collection URL generated successfully",
+        "data" => { "checkout_url" => card_url }
+      }
+    end
+
+    it "generates a card collection URL for a subscription" do
+      stub_request(:get, "#{base_url}checkout/generate-card-collection-url?subscription_id=sub_uuid_123")
+        .with(headers: { 'x-api-key' => api_key })
+        .to_return(
+          status: 200,
+          body: card_response.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      result = checkout_module.card_collection_url(subscription_id: "sub_uuid_123")
+      expect(result).to eq(card_url)
+    end
+
+    it "generates a card collection URL for an order" do
+      stub_request(:get, "#{base_url}checkout/generate-card-collection-url?order_id=order_uuid_456")
+        .with(headers: { 'x-api-key' => api_key })
+        .to_return(
+          status: 200,
+          body: card_response.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      result = checkout_module.card_collection_url(order_id: "order_uuid_456")
+      expect(result).to eq(card_url)
+    end
+
+    it "raises when neither subscription_id nor order_id is provided" do
+      expect { checkout_module.card_collection_url }
+        .to raise_error(ArgumentError, /Either subscription_id or order_id is required/)
+    end
+
+    it "raises when API returns an empty URL" do
+      stub_request(:get, "#{base_url}checkout/generate-card-collection-url?subscription_id=sub_uuid_123")
+        .to_return(
+          status: 200,
+          body: { "data" => { "checkout_url" => "" } }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      expect { checkout_module.card_collection_url(subscription_id: "sub_uuid_123") }
+        .to raise_error(StandardError, /Card collection URL could not be generated/)
+    end
+
+    it "validates API key" do
+      client_with_empty_key = MetrifoxSDK::Client.new(api_key: "")
+      expect { client_with_empty_key.checkout.card_collection_url(subscription_id: "sub_uuid_123") }
         .to raise_error(MetrifoxSDK::ConfigurationError, /API key required/)
     end
   end

--- a/spec/customers_spec.rb
+++ b/spec/customers_spec.rb
@@ -882,4 +882,74 @@ RSpec.describe MetrifoxSDK::Customers::Module do
         .to raise_error(MetrifoxSDK::APIError, /Failed to Fetch Customers: 500/)
     end
   end
+
+  describe "#archive" do
+    let(:expected_response) do
+      {
+        "statusCode" => 200,
+        "message" => "Customer Archived Successfully",
+        "data" => {
+          "customer_key" => customer_key,
+          "archived_at" => "2026-05-05T14:30:00Z"
+        }
+      }
+    end
+
+    it "archives a customer successfully" do
+      stub_request(:post, "#{base_url}customers/#{customer_key}/archive")
+        .with(headers: { 'x-api-key' => api_key })
+        .to_return(
+          status: 200,
+          body: expected_response.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      result = customers_module.archive(customer_key)
+      expect(result).to eq(expected_response)
+      expect(result["data"]["archived_at"]).to eq("2026-05-05T14:30:00Z")
+    end
+
+    it "handles API errors" do
+      stub_request(:post, "#{base_url}customers/#{customer_key}/archive")
+        .to_return(status: 404, body: { message: "Not found" }.to_json)
+
+      expect { customers_module.archive(customer_key) }
+        .to raise_error(MetrifoxSDK::APIError, /Failed to Archive Customer: 404/)
+    end
+  end
+
+  describe "#unarchive" do
+    let(:expected_response) do
+      {
+        "statusCode" => 200,
+        "message" => "Customer Unarchived Successfully",
+        "data" => {
+          "customer_key" => customer_key,
+          "archived_at" => nil
+        }
+      }
+    end
+
+    it "unarchives a customer successfully" do
+      stub_request(:post, "#{base_url}customers/#{customer_key}/unarchive")
+        .with(headers: { 'x-api-key' => api_key })
+        .to_return(
+          status: 200,
+          body: expected_response.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      result = customers_module.unarchive(customer_key)
+      expect(result).to eq(expected_response)
+      expect(result["data"]["archived_at"]).to be_nil
+    end
+
+    it "handles API errors" do
+      stub_request(:post, "#{base_url}customers/#{customer_key}/unarchive")
+        .to_return(status: 404, body: { message: "Not found" }.to_json)
+
+      expect { customers_module.unarchive(customer_key) }
+        .to raise_error(MetrifoxSDK::APIError, /Failed to Unarchive Customer: 404/)
+    end
+  end
 end

--- a/spec/metrifox_sdk_spec.rb
+++ b/spec/metrifox_sdk_spec.rb
@@ -131,6 +131,7 @@ RSpec.describe MetrifoxSDK do
       expect(usages).to respond_to(:check_access)
       expect(usages).to respond_to(:record_usage)
       expect(usages).to respond_to(:list_events)
+      expect(usages).to respond_to(:quantity_price)
       expect(usages).to respond_to(:get_tenant_id)
       expect(usages).to respond_to(:get_checkout_key)
     end

--- a/spec/metrifox_sdk_spec.rb
+++ b/spec/metrifox_sdk_spec.rb
@@ -41,8 +41,33 @@ RSpec.describe MetrifoxSDK do
       expect(client.web_app_base_url).to eq("https://staging.webapp.com")
     end
 
+    it "creates a client with custom meter service base URL" do
+      client = MetrifoxSDK.init(
+        api_key: "test-key",
+        meter_service_base_url: "https://meter.staging.metrifox.com/"
+      )
+      expect(client.meter_service_base_url).to eq("https://meter.staging.metrifox.com/")
+    end
+
+    it "falls back to METRIFOX_METER_SERVICE_BASE_URL env var" do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("METRIFOX_METER_SERVICE_BASE_URL").and_return("https://env-meter.metrifox.com/")
+
+      client = MetrifoxSDK.init(api_key: "test-key")
+      expect(client.meter_service_base_url).to eq("https://env-meter.metrifox.com/")
+    end
+
+    it "defaults meter_service_base_url to the production URL" do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("METRIFOX_METER_SERVICE_BASE_URL").and_return(nil)
+
+      client = MetrifoxSDK.init(api_key: "test-key")
+      expect(client.meter_service_base_url).to eq(MetrifoxSDK::Client::METER_SERVICE_BASE_URL)
+    end
+
     it "uses environment variable for API key when not provided" do
       allow(MetrifoxSDK::UtilMethods).to receive(:load_dotenv)
+      allow(ENV).to receive(:[]).and_call_original
       allow(ENV).to receive(:[]).with("METRIFOX_API_KEY").and_return("env-api-key")
 
       client = MetrifoxSDK.init
@@ -62,6 +87,11 @@ RSpec.describe MetrifoxSDK do
     it "provides access to subscriptions module" do
       client = MetrifoxSDK.init(api_key: "test-key")
       expect(client.subscriptions).to be_a(MetrifoxSDK::Subscriptions::Module)
+    end
+
+    it "provides access to wallets module" do
+      client = MetrifoxSDK.init(api_key: "test-key")
+      expect(client.wallets).to be_a(MetrifoxSDK::Wallets::Module)
     end
 
     it "returns the same module instance on multiple calls" do
@@ -100,6 +130,7 @@ RSpec.describe MetrifoxSDK do
       usages = client.usages
       expect(usages).to respond_to(:check_access)
       expect(usages).to respond_to(:record_usage)
+      expect(usages).to respond_to(:list_events)
       expect(usages).to respond_to(:get_tenant_id)
       expect(usages).to respond_to(:get_checkout_key)
     end
@@ -109,6 +140,24 @@ RSpec.describe MetrifoxSDK do
       expect(subscriptions).to respond_to(:get_billing_history)
       expect(subscriptions).to respond_to(:get_entitlements_summary)
       expect(subscriptions).to respond_to(:get_entitlements_usage)
+    end
+
+    it "wallets module responds to expected methods" do
+      wallets = client.wallets
+      expect(wallets).to respond_to(:list)
+      expect(wallets).to respond_to(:list_credit_allocations)
+      expect(wallets).to respond_to(:get_credit_allocation)
+    end
+
+    it "customers module responds to archive/unarchive" do
+      customers = client.customers
+      expect(customers).to respond_to(:archive)
+      expect(customers).to respond_to(:unarchive)
+    end
+
+    it "checkout module responds to card_collection_url" do
+      checkout = client.checkout
+      expect(checkout).to respond_to(:card_collection_url)
     end
   end
 end

--- a/spec/usages_spec.rb
+++ b/spec/usages_spec.rb
@@ -599,6 +599,82 @@ RSpec.describe MetrifoxSDK::Usages::Module do
         .to raise_error(MetrifoxSDK::APIError, /Failed to list usage events: 500/)
     end
   end
+
+  describe "#quantity_price" do
+    let(:expected_response) do
+      {
+        "message" => "Quantity price fetched",
+        "data" => {
+          "customer_key" => customer_key,
+          "feature_key" => "feature_interview_booking",
+          "quantity" => 500,
+          "price" => 3000.0,
+          "unit" => "USD",
+          "applied_tiers" => [
+            {
+              "first_unit" => 1,
+              "last_unit" => 500,
+              "pricing_model" => "per_unit",
+              "unit_price" => 6.0,
+              "units_consumed" => 500,
+              "tier_price" => "3000.0"
+            }
+          ]
+        }
+      }
+    end
+
+    it "computes quantity price for a customer + feature" do
+      stub_request(:get, "#{base_url}usage/quantity-price")
+        .with(
+          query: {
+            customer_key: customer_key,
+            feature_key: "feature_interview_booking",
+            quantity: 500
+          },
+          headers: { 'x-api-key' => api_key }
+        )
+        .to_return(
+          status: 200,
+          body: expected_response.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      result = usages_module.quantity_price(
+        customer_key: customer_key,
+        feature_key: "feature_interview_booking",
+        quantity: 500
+      )
+      expect(result).to eq(expected_response)
+      expect(result["data"]["price"]).to eq(3000.0)
+      expect(result["data"]["applied_tiers"].length).to eq(1)
+    end
+
+    it "handles API errors" do
+      stub_request(:get, "#{base_url}usage/quantity-price")
+        .with(query: hash_including(customer_key: customer_key))
+        .to_return(status: 403, body: { message: "Forbidden" }.to_json)
+
+      expect {
+        usages_module.quantity_price(
+          customer_key: customer_key,
+          feature_key: "feature_interview_booking",
+          quantity: 500
+        )
+      }.to raise_error(MetrifoxSDK::APIError, /Failed to compute quantity price: 403/)
+    end
+
+    it "validates API key" do
+      client_with_empty_key = MetrifoxSDK::Client.new(api_key: "")
+      expect {
+        client_with_empty_key.usages.quantity_price(
+          customer_key: customer_key,
+          feature_key: "feature_interview_booking",
+          quantity: 500
+        )
+      }.to raise_error(MetrifoxSDK::ConfigurationError, /API key required/)
+    end
+  end
 end
 
 # Integration tests to verify the modular interface works end-to-end

--- a/spec/usages_spec.rb
+++ b/spec/usages_spec.rb
@@ -525,6 +525,80 @@ RSpec.describe MetrifoxSDK::Usages::Module do
       expect(usages_module.send(:base_url)).to eq(base_url)
     end
   end
+
+  describe "#list_events" do
+    let(:events_response) do
+      {
+        "data" => [
+          {
+            "id" => "evt_uuid_1",
+            "event_id" => "client_event_1",
+            "customer_key" => customer_key,
+            "feature_key" => "feature_seats",
+            "quantity" => 1.0,
+            "timestamp" => 1714922200000,
+            "metadata" => {}
+          }
+        ],
+        "meta" => {
+          "current_page" => 1,
+          "next_page" => nil,
+          "prev_page" => nil,
+          "total_count" => 1,
+          "total_pages" => 1,
+          "per_page" => 25
+        }
+      }
+    end
+
+    it "lists usage events with no filters" do
+      stub_request(:get, "#{meter_service_base_url}usage/events")
+        .with(headers: { 'x-api-key' => api_key })
+        .to_return(
+          status: 200,
+          body: events_response.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      result = usages_module.list_events
+      expect(result).to eq(events_response)
+      expect(result["data"].first["customer_key"]).to eq(customer_key)
+    end
+
+    it "lists usage events with filters and pagination" do
+      stub_request(:get, "#{meter_service_base_url}usage/events")
+        .with(
+          query: {
+            customer_key: customer_key,
+            feature_key: "feature_seats",
+            page: 1,
+            per_page: 10
+          },
+          headers: { 'x-api-key' => api_key }
+        )
+        .to_return(
+          status: 200,
+          body: events_response.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      result = usages_module.list_events(
+        customer_key: customer_key,
+        feature_key: "feature_seats",
+        page: 1,
+        per_page: 10
+      )
+      expect(result["meta"]["current_page"]).to eq(1)
+    end
+
+    it "handles API errors" do
+      stub_request(:get, "#{meter_service_base_url}usage/events")
+        .to_return(status: 500, body: { message: "boom" }.to_json)
+
+      expect { usages_module.list_events }
+        .to raise_error(MetrifoxSDK::APIError, /Failed to list usage events: 500/)
+    end
+  end
 end
 
 # Integration tests to verify the modular interface works end-to-end

--- a/spec/wallets_spec.rb
+++ b/spec/wallets_spec.rb
@@ -1,0 +1,170 @@
+require_relative '../lib/metrifox_sdk/wallets/module'
+require 'spec_helper'
+require 'webmock/rspec'
+
+RSpec.describe MetrifoxSDK::Wallets::Module do
+  let(:api_key) { "test-api-key" }
+  let(:base_url) { "https://api.example.com/api/v1/" }
+  let(:client) { MetrifoxSDK::Client.new(api_key: api_key, base_url: base_url) }
+  let(:wallets_module) { client.wallets }
+  let(:customer_key) { "test_customer_123" }
+  let(:wallet_id) { "wallet_uuid_123" }
+  let(:allocation_id) { "alloc_uuid_123" }
+
+  before do
+    WebMock.disable_net_connect!(allow_localhost: false)
+  end
+
+  describe "#list" do
+    let(:expected_response) do
+      {
+        "statusCode" => 200,
+        "data" => [
+          {
+            "id" => wallet_id,
+            "name" => "API Credits",
+            "credit_unit_singular" => "credit",
+            "credit_unit_plural" => "credits",
+            "credit_system_id" => "cs_uuid_123",
+            "balance" => 100.0,
+            "credit_key" => "api_credits",
+            "customer_key" => customer_key,
+            "topup_link" => "https://app.metrifox.com/topup/abc"
+          }
+        ]
+      }
+    end
+
+    it "lists wallets for a customer" do
+      stub_request(:get, "#{base_url}credit_systems/v2/wallets")
+        .with(query: { customer_key: customer_key }, headers: { 'x-api-key' => api_key })
+        .to_return(
+          status: 200,
+          body: expected_response.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      result = wallets_module.list(customer_key)
+      expect(result).to eq(expected_response)
+      expect(result["data"].first["id"]).to eq(wallet_id)
+    end
+
+    it "handles API errors" do
+      stub_request(:get, "#{base_url}credit_systems/v2/wallets")
+        .with(query: { customer_key: customer_key })
+        .to_return(status: 500, body: { message: "boom" }.to_json)
+
+      expect { wallets_module.list(customer_key) }
+        .to raise_error(MetrifoxSDK::APIError, /Failed to list wallets: 500/)
+    end
+
+    it "validates API key" do
+      empty_client = MetrifoxSDK::Client.new(api_key: "")
+      expect { empty_client.wallets.list(customer_key) }
+        .to raise_error(MetrifoxSDK::ConfigurationError, /API key required/)
+    end
+  end
+
+  describe "#list_credit_allocations" do
+    let(:expected_response) do
+      {
+        "statusCode" => 200,
+        "data" => [
+          {
+            "id" => allocation_id,
+            "amount" => 50.0,
+            "consumed" => 10.0,
+            "created_at" => "2026-05-01T10:00:00Z",
+            "allocation_type" => "purchased",
+            "order_id" => "order_uuid_1",
+            "invoice_id" => "inv_uuid_1",
+            "order_number" => "ORD-001",
+            "valid_until" => "2027-05-01T10:00:00Z",
+            "transactions" => []
+          }
+        ]
+      }
+    end
+
+    it "lists credit allocations for a wallet" do
+      stub_request(:get, "#{base_url}credit_systems/v2/wallets/#{wallet_id}/credit-allocations")
+        .with(headers: { 'x-api-key' => api_key })
+        .to_return(
+          status: 200,
+          body: expected_response.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      result = wallets_module.list_credit_allocations(wallet_id)
+      expect(result["data"].first["id"]).to eq(allocation_id)
+    end
+
+    it "lists credit allocations filtered by status" do
+      stub_request(:get, "#{base_url}credit_systems/v2/wallets/#{wallet_id}/credit-allocations")
+        .with(query: { status: "active" }, headers: { 'x-api-key' => api_key })
+        .to_return(
+          status: 200,
+          body: expected_response.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      result = wallets_module.list_credit_allocations(wallet_id, status: "active")
+      expect(result["data"].first["allocation_type"]).to eq("purchased")
+    end
+
+    it "handles API errors" do
+      stub_request(:get, "#{base_url}credit_systems/v2/wallets/#{wallet_id}/credit-allocations")
+        .to_return(status: 404, body: { message: "Not found" }.to_json)
+
+      expect { wallets_module.list_credit_allocations(wallet_id) }
+        .to raise_error(MetrifoxSDK::APIError, /Failed to list credit allocations: 404/)
+    end
+  end
+
+  describe "#get_credit_allocation" do
+    let(:expected_response) do
+      {
+        "statusCode" => 200,
+        "data" => {
+          "id" => allocation_id,
+          "amount" => 100.0,
+          "consumed" => 25.0,
+          "created_at" => "2026-05-01T10:00:00Z",
+          "allocation_type" => "purchased",
+          "transactions" => [
+            {
+              "id" => "txn_1",
+              "amount" => 25.0,
+              "created_at" => "2026-05-02T11:00:00Z",
+              "quantity" => 25.0,
+              "event_name" => "api_call",
+              "usage_event_id" => "evt_uuid_1"
+            }
+          ]
+        }
+      }
+    end
+
+    it "gets a single credit allocation with transactions" do
+      stub_request(:get, "#{base_url}credit_systems/v2/credit-allocations/#{allocation_id}")
+        .with(headers: { 'x-api-key' => api_key })
+        .to_return(
+          status: 200,
+          body: expected_response.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      result = wallets_module.get_credit_allocation(allocation_id)
+      expect(result).to eq(expected_response)
+      expect(result["data"]["transactions"].length).to eq(1)
+    end
+
+    it "handles API errors" do
+      stub_request(:get, "#{base_url}credit_systems/v2/credit-allocations/#{allocation_id}")
+        .to_return(status: 404, body: { message: "Not found" }.to_json)
+
+      expect { wallets_module.get_credit_allocation(allocation_id) }
+        .to raise_error(MetrifoxSDK::APIError, /Failed to get credit allocation: 404/)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Brings the Ruby SDK in line with the Python SDK update (metrifox/metrifox-python#6) and adds the new `quantity-price` endpoint:

- **Wallets module**: `wallets.list(customer_key)`, `wallets.list_credit_allocations(wallet_id, status:)`, `wallets.get_credit_allocation(allocation_id)`
- **Customer archive**: `customers.archive(customer_key)` and `customers.unarchive(customer_key)`
- **Card collection URL**: `checkout.card_collection_url(subscription_id:, order_id:)`
- **Usage event listing**: `usages.list_events(customer_key:, feature_key:, page:, per_page:)`
- **Quantity price**: `usages.quantity_price(customer_key:, feature_key:, quantity:)` — computes a price for a given usage quantity (requires finance API feature)
- **Configurable meter service URL**: `meter_service_base_url` config option, with `METRIFOX_METER_SERVICE_BASE_URL` env-var fallback

Bumps version to `1.3.0` and updates the CHANGELOG + README accordingly.

## Test plan

- [x] `bundle exec rspec` — 106 examples, 0 failures
- [x] Live integration test (`test-ruby-sdk/test_integration.rb`) hitting production:
  - [x] `customers.archive` → returns `archived_at` timestamp
  - [x] `customers.unarchive` → clears `archived_at`
  - [x] `usages.list_events` → returns paginated events
  - [x] `wallets.list` → returns wallet array
  - [x] `usages.quantity_price(...)` → `{ price: "30.0", unit: "USD", applied_tiers: [...] }`

> Note: `checkout.card_collection_url` returned a `500` from the API in live testing against a known subscription — the SDK shape is correct (same as Python), so this is likely a server-side issue worth investigating separately.

cc @metrifox/backend-team

🤖 Generated with [Claude Code](https://claude.com/claude-code)