### PR TITLE
Pr check fix - bundler-audit: print findings to the step log too

### DIFF
--- a/.github/scripts/bundler-audit.sh
+++ b/.github/scripts/bundler-audit.sh
@@ -36,13 +36,16 @@ while IFS= read -r lock; do
     printf '|-----|---------|----------|----------|--------|------------|\n'
   } >> "$GITHUB_STEP_SUMMARY"
   # Per-finding status (report-only if its dir is report-only OR its advisory id
-  # is allow-listed). awk exits 1 if any finding blocks.
+  # is allow-listed). awk writes the table to the Summary, a plain list to the
+  # step log (stdout), and one annotation per finding. Exits 1 if any blocks.
+  printf -- '── %s — %s findings ──\n' "$dir" "$dir_mode"
   if ! printf '%s\n' "$out" | awk -v dir_mode="$dir_mode" -v allow=" $REPORT_ONLY_IDS " '
     function flush(){ if(name=="")return; adv=(cve!=""?cve:ghsa);
       ro=(dir_mode=="report-only");
       if(index(allow," " cve " ")>0 || index(allow," " ghsa " ")>0) ro=1;
       status=ro?"🟡 report-only":"🔴 blocking";
       printf("| %s | %s | %s | [%s](%s) | %s | %s |\n",name,ver,crit,adv,url,status,sol) >> ENVIRON["GITHUB_STEP_SUMMARY"];
+      printf("  • %s %s (%s %s, %s) — %s\n",name,ver,crit,adv,(ro?"report-only":"blocking"),sol);
       if(ro) printf("::warning::%s %s (%s %s, report-only) — %s\n",name,ver,crit,adv,sol);
       else { printf("::error::%s %s (%s %s) — %s\n",name,ver,crit,adv,sol); blocking++ }
       name=ver=cve=ghsa=crit=url=sol="" }


### PR DESCRIPTION
## What
The `bundler-audit` script wrote its findings table to the PR check's **Summary page**, but the **step log** only showed annotations. This adds a plain per-finding list to stdout so findings are clearly visible inline in the Actions log.

No behavior/check-name change — purely additional logging. Matches the same change applied to js (`npm audit`) and python (`pip audit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)